### PR TITLE
ISSUE-17-18-BugFix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 `JSLTransitionLib` adheres to [Semantic Versioning](http://semver.org/).
 
 ---
+## [3.0.1](https://github.com/Jason-Stan-Lee/JSLTransitionLib/releases/tag/3.0.1) / 2019-12-11
+* Fix some bugs for `interactiveTransitionShouldInterrupt` in complex transitionings
+* Only the rootViewController of NavigationController will enable interactive dismiss as a default 
+
 ## [3.0.0](https://github.com/Jason-Stan-Lee/JSLTransitionLib/releases/tag/3.0.0) / 2019-11-10
 
 * Add current process argument in handling interaction transition complete percent

--- a/JSLTransitionLib.podspec
+++ b/JSLTransitionLib.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'JSLTransitionLib'
-  s.version          = '3.0.0'
+  s.version          = '3.0.1'
   s.summary          = 'Help you to hold custom view transitions EASYLY !'
   s.swift_version = '4.2'
   s.platform = 'ios'

--- a/JSLTransitionLib/Classes/TransitionControllers/ViewControllerTransitionDelegate.swift
+++ b/JSLTransitionLib/Classes/TransitionControllers/ViewControllerTransitionDelegate.swift
@@ -98,7 +98,7 @@ public final class ViewControllerTransitionDelegate: NSObject {
             // 重置平移速度
             interactiveGr.setTranslation(CGPoint.zero, in: interactivePresentingViewController?.view)
         default:
-            handleInteractiveGestureStateEnd(interactiveGr, with: presentedVC, ignoreGrState: false)
+            handleInteractiveGestureStateEnd(interactiveGr, with: presentedVC)
         }
     }
     
@@ -173,10 +173,9 @@ public final class ViewControllerTransitionDelegate: NSObject {
         // 是否需要中断交互转场
         let shouldInterrupt = presentedVC.interactiveTransitionShouldInterrupt(for: currentInteractiveTransitionType, currentProcess: interactiveTransitionPercentComplete)
         if shouldInterrupt {
-            // 如果中断交互转场，则根据当前
-            handleInteractiveGestureStateEnd(interactiveGr,
-                                             with: presentedVC,
-                                             ignoreGrState: true)
+            // 中断手势
+            interactiveGr.isEnabled = false
+            interactiveGr.isEnabled = true
         }
     }
     
@@ -185,8 +184,7 @@ public final class ViewControllerTransitionDelegate: NSObject {
     /// - Parameter presentedVC: 转场 VC
     /// - Parameter ignoreGrState: 是否需要忽略转场手势状态
     private func handleInteractiveGestureStateEnd(_ interactiveGr: UIPanGestureRecognizer,
-                                                  with presentedVC: UIViewController,
-                                                  ignoreGrState: Bool) {
+                                                  with presentedVC: UIViewController) {
         
         // 手势结束或者取消时，确认 interactiveTransition 是否已经赋值
         guard let interactiveTransition = interactiveTransition else {
@@ -205,7 +203,7 @@ public final class ViewControllerTransitionDelegate: NSObject {
         interactiveTransitionPercentComplete = min(interactiveTransitionPercentComplete, 1)
         interactiveTransitionPercentComplete = max(0, interactiveTransitionPercentComplete)
         
-        if ((ignoreGrState || interactiveGr.state == .ended)
+        if ((!interactiveGr.isEnabled || interactiveGr.state == .ended)
             && interactiveTransitionPercentComplete >= 0.4)
             || interactiveTransitionPercentComplete == 1 { // 完成
             interactiveTransition.finish()
@@ -350,8 +348,11 @@ extension ViewControllerTransitionDelegate: UIViewControllerTransitioningDelegat
         return interactiveTransition
     }
 
-    public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
-        return presented.presentationController(for: presented, presenting: presenting, source: source) ?? UIPresentationController(presentedViewController: presented, presenting: presenting)
+    public func presentationController(forPresented presented: UIViewController,
+                                       presenting: UIViewController?,
+                                       source: UIViewController) -> UIPresentationController? {
+        return presented.presentationController(for: presented, presenting: presenting, source: source)
+            ?? UIPresentationController(presentedViewController: presented, presenting: presenting)
     }
 }
 

--- a/JSLTransitionLib/Classes/TransitionControllers/ViewControllerTransitionProtocol.swift
+++ b/JSLTransitionLib/Classes/TransitionControllers/ViewControllerTransitionProtocol.swift
@@ -8,9 +8,10 @@ import UIKit
 ///
 /// - dismiss: 模态消失
 /// - presented: 被模态推出
-/// - presentTo: 模态推出其他视图
+/// - presentTo: 交互模态推出其他视图
 /// - none: 无转场
-@objc public enum ModalTransitioningType: Int {
+@objc(JSLModalTransitioningType)
+public enum ModalTransitioningType: Int {
     case dismiss, presented, presentTo, none
 
     /// 是否支持手势交互
@@ -132,7 +133,7 @@ extension UIViewController: ViewControllerTransitionProtocol {
         get {
             let dismissEnable = childViewControllerForViewControllerTransitioning()?.isInteractiveDismissEnable
             guard let value = objc_getAssociatedObject(self, &AssociatedKeys.isInteractiveDismissEnable) as? Bool else {
-                return dismissEnable ?? true
+                return dismissEnable ?? isFistViewController()
             }
             return dismissEnable ?? value
         }
@@ -255,6 +256,21 @@ extension UIViewController: ViewControllerTransitionProtocol {
         return nil
     }
     
+    /// 当前页面是否为视图控制器
+    private func isFistViewController() -> Bool {
+        if let navigationController = self as? UINavigationController {
+            return navigationController.children.count == 1
+        }
+
+        if let tabBarController = self as? UITabBarController {
+            return tabBarController.children.count == 1
+        }
+        if let navigation = navigationController {
+            return navigation.children.count == 1
+        }
+        return true
+    }
+
 }
 
 //----------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ func interactivePopGestureShouldBegin(translation: CGPoint) -> Bool
 /// - Returns: 完成进度 0 ~ 1
 func navigationInteractivePopCompletePercent(currentProgress: CGFloat, translation: CGPoint, startPoint: CGPoint) -> CGFloat
 
+/// 根据 currentProcess 等判断交互转场是否需要中断，默认为 false。即交互手势尚未结束时，是否强制中断交互控制
+func interactiveTransitionShouldInterrupt(for transitionType: ModalTransitioningType, currentProcess: CGFloat) -> Bool
+                                          
 ```
 - 交互转场过程
 


### PR DESCRIPTION
* Fix some bugs for `interactiveTransitionShouldInterrupt` in complex transitionings
* Only the rootViewController of NavigationController will enable interactive dismiss as a default 